### PR TITLE
Increase ticker interval in server Run function

### DIFF
--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -335,7 +335,7 @@ func Run() {
 
 	go func() {
 		timeout := 3 * time.Minute
-		ticker := time.NewTicker(5 * time.Second)
+		ticker := time.NewTicker(1 * time.Minute)
 		defer ticker.Stop()
 
 		for range ticker.C {


### PR DESCRIPTION
Changed the ticker interval from 5 seconds to 1 minute in the Run function's goroutine to reduce frequency of periodic tasks .