### PR TITLE
Update embedded assets to embed output.css only

### DIFF
--- a/internal/web/assets_embed.go
+++ b/internal/web/assets_embed.go
@@ -6,5 +6,5 @@ import (
 
 // embeddedAssets contains the compiled CSS/JS for the web UI.
 //
-//go:embed assets/* assets/css/* assets/js/* assets/icons/*
+//go:embed assets/css/output.css assets/js/* assets/icons/*
 var embeddedAssets embed.FS


### PR DESCRIPTION
Changed the go:embed directive to include only assets/css/output.css instead of all files in assets/css. This ensures only the compiled CSS is embedded, reducing unnecessary files in the binary.